### PR TITLE
INDM eNL cleanup

### DIFF
--- a/tenants/all/templates/fm-product-showcase.marko
+++ b/tenants/all/templates/fm-product-showcase.marko
@@ -2,10 +2,10 @@ import contentList from "@industrial-media/common/graphql/fragments/content-list
 
 $ const { website } = out.global;
 $ const { newsletter, date } = data;
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;"
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "14px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -16,8 +16,8 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
   "margin-top": "3px !important",
   "line-height": "1.2em",
@@ -84,18 +84,13 @@ $ const teaserStyle = {
                         </td>
                       </tr>
                     </common-table>
-                    <common-table width="20" align="left" padding=0 spacing=0>
-                      <tr>
-                        <td>&nbsp;</td>
-                      </tr>
-                    </common-table>
-                    <common-table width="295" class="right" align="right" padding=0 spacing=0>
+                    <common-table width="295" class="main" align="right" padding=0 spacing=0>
                       <tr>
                         <td>
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
                       </tr>
                     </common-table>

--- a/tenants/all/templates/fm-today.marko
+++ b/tenants/all/templates/fm-today.marko
@@ -6,11 +6,11 @@ import GAM from "../config/gam";
 $ const { website } = out.global;
 $ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#dc0607";
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;";
 $ const titleStyle = "text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #000000; text-align: left; font-weight: bold;";
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "16px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -21,27 +21,26 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
   "line-height": "1.2em",
 };
 $ const textAdCopyStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "font-size": "12px",
-  color: "#000000",
-  "line-height": "1em",
+  "color": "#000000",
   "text-align": "left",
   "line-height": "18px",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
   "text-decoration": "none",
   "text-align": "left",
-  background: "#3B579D",
-  color: "#ffffff",
+  "background": "#3B579D",
+  "color": "#ffffff",
   "font-weight": "bold",
   "font-size": "16px",
   "margin-top": "10px",
@@ -142,10 +141,10 @@ $ const textAdButtonLinkStyle = {
                 </marko-newsletter-imgix>
               </marko-core-obj-value>
 
-              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
-              <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </for>
           </marko-web-query>
         </td>
@@ -194,11 +193,14 @@ $ const textAdButtonLinkStyle = {
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
 
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
                       </tr>
                     </common-table>
                   </for>
@@ -214,7 +216,7 @@ $ const textAdButtonLinkStyle = {
             sectionId: 63313,
             queryFragment: contentList,
           }>
-            <!-- Left Wrapping Table -->
+            <!-- Right Wrapping Table -->
             <common-table width="300" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
               <tr>
                 <td valign="top">
@@ -248,7 +250,9 @@ $ const textAdButtonLinkStyle = {
                               </td>
                             </tr>
                           </common-table>
-                          <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
+                          <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
                           <common-table align="right" class="main" padding=0 spacing=0>
                             <tr>
                               <td style=`${textAdButtonStyle}`>
@@ -274,9 +278,7 @@ $ const textAdButtonLinkStyle = {
 
         </td>
       </tr>
-      <tr>
-        <td>&nbsp;</td>
-      </tr>
+
       <tr>
         <td><hr></td>
       </tr>
@@ -323,7 +325,7 @@ $ const textAdButtonLinkStyle = {
                       <marko-core-obj-text obj=node field="name" >
                         <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                       </marko-core-obj-text>
-                      <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                     </td>
                   </tr>
                   <tr>
@@ -333,66 +335,61 @@ $ const textAdButtonLinkStyle = {
               </if>
               <else-if(node.type === 'text-ad')>
                 <!-- Left Wrapping Table -->
-                <common-table width="630" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
+
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
                   <tr>
-                    <td valign="top">
-                      <common-table width="630" style="border-collapse:collapse;" align="left" class="right" padding=10 spacing=0>
+                    <td bgcolor="#ecedee">
+                      <marko-core-obj-text obj=node field="name">
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <common-table
+                        style="margin:10px 10px 0 0;"
+                        align="left"
+                        class="left"
+                        padding=5
+                        spacing=0
+                      >
                         <tr>
-                          <td bgcolor="#ecedee">
-                            <marko-core-obj-text obj=node field="name">
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-                            <common-table
-                              style="margin:10px 10px 0 0;"
-                              align="left"
-                              class="left"
-                              padding=0
-                              spacing=0
-                            >
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 150 }
-                                      class="main"
-                                      attrs={ border: 0, width: 150 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
-                            <common-table align="right" class="main" padding=0 spacing=0>
-                              <tr>
-                                <td style=`${textAdButtonStyle}`>
-                                  <marko-core-obj-text obj=node field="linkText" html=true >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
-                                  </marko-core-obj-text>
-                                </td>
-                              </tr>
-                            </common-table>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options={ w: 150 }
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
                           </td>
                         </tr>
                       </common-table>
-                      <common-table width="100%" align="center" class="center" >
+
+                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                      <common-table align="right" class="main" padding=0 spacing=0>
                         <tr>
-                          <td>&nbsp;</td>
+                          <td style=`${textAdButtonStyle}`>
+                            <marko-core-obj-text obj=node field="linkText" html=true >
+                              <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                            </marko-core-obj-text>
+                          </td>
                         </tr>
                       </common-table>
                     </td>
                   </tr>
+
                 </common-table>
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+
               </else-if>
             </for>
           </marko-web-query>
         </td>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
       </tr>
     </common-table>
 

--- a/tenants/all/templates/id-product-showcase.marko
+++ b/tenants/all/templates/id-product-showcase.marko
@@ -2,10 +2,10 @@ import contentList from "@industrial-media/common/graphql/fragments/content-list
 
 $ const { website } = out.global;
 $ const { newsletter, date } = data;
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;"
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "14px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -16,8 +16,8 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
   "margin-top": "3px !important",
   "line-height": "1.2em",
@@ -83,18 +83,13 @@ $ const teaserStyle = {
                         </td>
                       </tr>
                     </common-table>
-                    <common-table width="20" align="left" padding=0 spacing=0>
-                      <tr>
-                        <td>&nbsp;</td>
-                      </tr>
-                    </common-table>
-                    <common-table width="295" class="right" align="right" padding=0 spacing=0>
+                    <common-table width="295" class="main" align="right" padding=0 spacing=0>
                       <tr>
                         <td>
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
                       </tr>
                     </common-table>
@@ -104,6 +99,9 @@ $ const teaserStyle = {
             </for>
           </marko-web-query>
         </td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
       </tr>
     </common-table>
 

--- a/tenants/all/templates/id-today.marko
+++ b/tenants/all/templates/id-today.marko
@@ -6,11 +6,11 @@ import GAM from "../config/gam";
 $ const { website } = out.global;
 $ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#ef6422";
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;";
 $ const titleStyle = "text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #000000; text-align: left; font-weight: bold;";
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "16px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -21,28 +21,27 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
   "line-height": "1.2em",
 };
 $ const textAdCopyStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "font-size": "12px",
-  color: "#000000",
-  "line-height": "1em",
+  "color": "#000000",
   "text-align": "left",
   "line-height": "18px",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
-  background: "#3B579D",
-  color: "#ffffff",
+  "background": "#3B579D",
+  "color": "#ffffff",
   "font-weight": "bold",
   "font-size": "16px",
   "margin-top": "10px",
@@ -143,10 +142,10 @@ $ const textAdButtonLinkStyle = {
                 </marko-newsletter-imgix>
               </marko-core-obj-value>
 
-              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
-              <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </for>
           </marko-web-query>
         </td>
@@ -195,11 +194,14 @@ $ const textAdButtonLinkStyle = {
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
 
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
                       </tr>
                     </common-table>
                   </for>
@@ -215,7 +217,7 @@ $ const textAdButtonLinkStyle = {
             sectionId: 63308,
             queryFragment: contentList,
           }>
-            <!-- Left Wrapping Table -->
+            <!-- Right Wrapping Table -->
             <common-table width="300" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
               <tr>
                 <td valign="top">
@@ -249,7 +251,9 @@ $ const textAdButtonLinkStyle = {
                               </td>
                             </tr>
                           </common-table>
-                          <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
+                          <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
                           <common-table align="right" class="main" padding=0 spacing=0>
                             <tr>
                               <td style=`${textAdButtonStyle}`>
@@ -275,9 +279,7 @@ $ const textAdButtonLinkStyle = {
 
         </td>
       </tr>
-      <tr>
-        <td>&nbsp;</td>
-      </tr>
+
       <tr>
         <td><hr></td>
       </tr>
@@ -324,7 +326,7 @@ $ const textAdButtonLinkStyle = {
                       <marko-core-obj-text obj=node field="name" >
                         <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                       </marko-core-obj-text>
-                      <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                     </td>
                   </tr>
                   <tr>
@@ -334,66 +336,61 @@ $ const textAdButtonLinkStyle = {
               </if>
               <else-if(node.type === 'text-ad')>
                 <!-- Left Wrapping Table -->
-                <common-table width="630" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
+
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
                   <tr>
-                    <td valign="top">
-                      <common-table width="630" style="border-collapse:collapse;" align="left" class="right" padding=10 spacing=0>
+                    <td bgcolor="#ecedee">
+                      <marko-core-obj-text obj=node field="name">
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <common-table
+                        style="margin:10px 10px 0 0;"
+                        align="left"
+                        class="left"
+                        padding=5
+                        spacing=0
+                      >
                         <tr>
-                          <td bgcolor="#ecedee">
-                            <marko-core-obj-text obj=node field="name">
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-                            <common-table
-                              style="margin:10px 10px 0 0;"
-                              align="left"
-                              class="left"
-                              padding=0
-                              spacing=0
-                            >
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 150 }
-                                      class="main"
-                                      attrs={ border: 0, width: 150 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
-                            <common-table align="right" class="main" padding=0 spacing=0>
-                              <tr>
-                                <td style=`${textAdButtonStyle}`>
-                                  <marko-core-obj-text obj=node field="linkText" html=true >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
-                                  </marko-core-obj-text>
-                                </td>
-                              </tr>
-                            </common-table>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options={ w: 150 }
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
                           </td>
                         </tr>
                       </common-table>
-                      <common-table width="100%" align="center" class="center" >
+
+                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                      <common-table align="right" class="main" padding=0 spacing=0>
                         <tr>
-                          <td>&nbsp;</td>
+                          <td style=`${textAdButtonStyle}`>
+                            <marko-core-obj-text obj=node field="linkText" html=true >
+                              <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                            </marko-core-obj-text>
+                          </td>
                         </tr>
                       </common-table>
                     </td>
                   </tr>
+
                 </common-table>
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+
               </else-if>
             </for>
           </marko-web-query>
         </td>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
       </tr>
     </common-table>
 

--- a/tenants/all/templates/impo-mag-product-showcase.marko
+++ b/tenants/all/templates/impo-mag-product-showcase.marko
@@ -2,10 +2,10 @@ import contentList from "@industrial-media/common/graphql/fragments/content-list
 
 $ const { website } = out.global;
 $ const { newsletter, date } = data;
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;"
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "14px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -16,8 +16,8 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
   "margin-top": "3px !important",
   "line-height": "1.2em",
@@ -83,18 +83,13 @@ $ const teaserStyle = {
                         </td>
                       </tr>
                     </common-table>
-                    <common-table width="20" align="left" padding=0 spacing=0>
-                      <tr>
-                        <td>&nbsp;</td>
-                      </tr>
-                    </common-table>
-                    <common-table width="295" class="right" align="right" padding=0 spacing=0>
+                    <common-table width="295" class="main" align="right" padding=0 spacing=0>
                       <tr>
                         <td>
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
                       </tr>
                     </common-table>

--- a/tenants/all/templates/impo-mag-today.marko
+++ b/tenants/all/templates/impo-mag-today.marko
@@ -6,11 +6,11 @@ import GAM from "../config/gam";
 $ const { website } = out.global;
 $ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#ec1a23";
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;";
 $ const titleStyle = "text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #000000; text-align: left; font-weight: bold;";
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "16px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -21,28 +21,27 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
   "line-height": "1.2em",
 };
 $ const textAdCopyStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "font-size": "12px",
-  color: "#000000",
-  "line-height": "1em",
+  "color": "#000000",
   "text-align": "left",
   "line-height": "18px",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
-  background: "#3B579D",
-  color: "#ffffff",
+  "background": "#3B579D",
+  "color": "#ffffff",
   "font-weight": "bold",
   "font-size": "16px",
   "margin-top": "10px",
@@ -143,10 +142,10 @@ $ const textAdButtonLinkStyle = {
                 </marko-newsletter-imgix>
               </marko-core-obj-value>
 
-              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
-              <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </for>
           </marko-web-query>
         </td>
@@ -195,11 +194,14 @@ $ const textAdButtonLinkStyle = {
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
 
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
                       </tr>
                     </common-table>
                   </for>
@@ -215,7 +217,7 @@ $ const textAdButtonLinkStyle = {
             sectionId: 63318,
             queryFragment: contentList,
           }>
-            <!-- Left Wrapping Table -->
+            <!-- Right Wrapping Table -->
             <common-table width="300" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
               <tr>
                 <td valign="top">
@@ -249,7 +251,9 @@ $ const textAdButtonLinkStyle = {
                               </td>
                             </tr>
                           </common-table>
-                          <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
+                          <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
                           <common-table align="right" class="main" padding=0 spacing=0>
                             <tr>
                               <td style=`${textAdButtonStyle}`>
@@ -275,9 +279,7 @@ $ const textAdButtonLinkStyle = {
 
         </td>
       </tr>
-      <tr>
-        <td>&nbsp;</td>
-      </tr>
+
       <tr>
         <td><hr></td>
       </tr>
@@ -324,7 +326,7 @@ $ const textAdButtonLinkStyle = {
                       <marko-core-obj-text obj=node field="name" >
                         <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                       </marko-core-obj-text>
-                      <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                     </td>
                   </tr>
                   <tr>
@@ -334,66 +336,61 @@ $ const textAdButtonLinkStyle = {
               </if>
               <else-if(node.type === 'text-ad')>
                 <!-- Left Wrapping Table -->
-                <common-table width="630" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
+
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
                   <tr>
-                    <td valign="top">
-                      <common-table width="630" style="border-collapse:collapse;" align="left" class="right" padding=10 spacing=0>
+                    <td bgcolor="#ecedee">
+                      <marko-core-obj-text obj=node field="name">
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <common-table
+                        style="margin:10px 10px 0 0;"
+                        align="left"
+                        class="left"
+                        padding=5
+                        spacing=0
+                      >
                         <tr>
-                          <td bgcolor="#ecedee">
-                            <marko-core-obj-text obj=node field="name">
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-                            <common-table
-                              style="margin:10px 10px 0 0;"
-                              align="left"
-                              class="left"
-                              padding=0
-                              spacing=0
-                            >
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 150 }
-                                      class="main"
-                                      attrs={ border: 0, width: 150 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
-                            <common-table align="right" class="main" padding=0 spacing=0>
-                              <tr>
-                                <td style=`${textAdButtonStyle}`>
-                                  <marko-core-obj-text obj=node field="linkText" html=true >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
-                                  </marko-core-obj-text>
-                                </td>
-                              </tr>
-                            </common-table>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options={ w: 150 }
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
                           </td>
                         </tr>
                       </common-table>
-                      <common-table width="100%" align="center" class="center" >
+
+                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                      <common-table align="right" class="main" padding=0 spacing=0>
                         <tr>
-                          <td>&nbsp;</td>
+                          <td style=`${textAdButtonStyle}`>
+                            <marko-core-obj-text obj=node field="linkText" html=true >
+                              <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                            </marko-core-obj-text>
+                          </td>
                         </tr>
                       </common-table>
                     </td>
                   </tr>
+
                 </common-table>
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+
               </else-if>
             </for>
           </marko-web-query>
         </td>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
       </tr>
     </common-table>
 

--- a/tenants/all/templates/manufacturing-product-showcase.marko
+++ b/tenants/all/templates/manufacturing-product-showcase.marko
@@ -2,10 +2,10 @@ import contentList from "@industrial-media/common/graphql/fragments/content-list
 
 $ const { website } = out.global;
 $ const { newsletter, date } = data;
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;"
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "14px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -16,8 +16,8 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
   "margin-top": "3px !important",
   "line-height": "1.2em",
@@ -83,18 +83,13 @@ $ const teaserStyle = {
                         </td>
                       </tr>
                     </common-table>
-                    <common-table width="20" align="left" padding=0 spacing=0>
-                      <tr>
-                        <td>&nbsp;</td>
-                      </tr>
-                    </common-table>
-                    <common-table width="295" class="right" align="right" padding=0 spacing=0>
+                    <common-table width="295" class="main" align="right" padding=0 spacing=0>
                       <tr>
                         <td>
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
                       </tr>
                     </common-table>

--- a/tenants/all/templates/manufacturing-today.marko
+++ b/tenants/all/templates/manufacturing-today.marko
@@ -6,11 +6,11 @@ import GAM from "../config/gam";
 $ const { website } = out.global;
 $ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#c93a3a";
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;";
 $ const titleStyle = "text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #000000; text-align: left; font-weight: bold;";
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "16px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -21,28 +21,27 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
   "line-height": "1.2em",
 };
 $ const textAdCopyStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "font-size": "12px",
-  color: "#000000",
-  "line-height": "1em",
+  "color": "#000000",
   "text-align": "left",
   "line-height": "18px",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
-  background: "#3B579D",
-  color: "#ffffff",
+  "background": "#3B579D",
+  "color": "#ffffff",
   "font-weight": "bold",
   "font-size": "16px",
   "margin-top": "10px",
@@ -144,10 +143,10 @@ $ const textAdButtonLinkStyle = {
                 </marko-newsletter-imgix>
               </marko-core-obj-value>
 
-              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
-              <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </for>
           </marko-web-query>
         </td>
@@ -196,11 +195,14 @@ $ const textAdButtonLinkStyle = {
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
 
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
                       </tr>
                     </common-table>
                   </for>
@@ -216,7 +218,7 @@ $ const textAdButtonLinkStyle = {
             sectionId: 63323,
             queryFragment: contentList,
           }>
-            <!-- Left Wrapping Table -->
+            <!-- Right Wrapping Table -->
             <common-table width="300" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
               <tr>
                 <td valign="top">
@@ -250,7 +252,9 @@ $ const textAdButtonLinkStyle = {
                               </td>
                             </tr>
                           </common-table>
-                          <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
+                          <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
                           <common-table align="right" class="main" padding=0 spacing=0>
                             <tr>
                               <td style=`${textAdButtonStyle}`>
@@ -276,9 +280,7 @@ $ const textAdButtonLinkStyle = {
 
         </td>
       </tr>
-      <tr>
-        <td>&nbsp;</td>
-      </tr>
+
       <tr>
         <td><hr></td>
       </tr>
@@ -325,7 +327,7 @@ $ const textAdButtonLinkStyle = {
                       <marko-core-obj-text obj=node field="name" >
                         <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                       </marko-core-obj-text>
-                      <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                     </td>
                   </tr>
                   <tr>
@@ -335,66 +337,61 @@ $ const textAdButtonLinkStyle = {
               </if>
               <else-if(node.type === 'text-ad')>
                 <!-- Left Wrapping Table -->
-                <common-table width="630" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
+
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
                   <tr>
-                    <td valign="top">
-                      <common-table width="630" style="border-collapse:collapse;" align="left" class="right" padding=10 spacing=0>
+                    <td bgcolor="#ecedee">
+                      <marko-core-obj-text obj=node field="name">
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <common-table
+                        style="margin:10px 10px 0 0;"
+                        align="left"
+                        class="left"
+                        padding=5
+                        spacing=0
+                      >
                         <tr>
-                          <td bgcolor="#ecedee">
-                            <marko-core-obj-text obj=node field="name">
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-                            <common-table
-                              style="margin:10px 10px 0 0;"
-                              align="left"
-                              class="left"
-                              padding=0
-                              spacing=0
-                            >
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 150 }
-                                      class="main"
-                                      attrs={ border: 0, width: 150 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
-                            <common-table align="right" class="main" padding=0 spacing=0>
-                              <tr>
-                                <td style=`${textAdButtonStyle}`>
-                                  <marko-core-obj-text obj=node field="linkText" html=true >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
-                                  </marko-core-obj-text>
-                                </td>
-                              </tr>
-                            </common-table>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options={ w: 150 }
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
                           </td>
                         </tr>
                       </common-table>
-                      <common-table width="100%" align="center" class="center" >
+
+                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                      <common-table align="right" class="main" padding=0 spacing=0>
                         <tr>
-                          <td>&nbsp;</td>
+                          <td style=`${textAdButtonStyle}`>
+                            <marko-core-obj-text obj=node field="linkText" html=true >
+                              <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                            </marko-core-obj-text>
+                          </td>
                         </tr>
                       </common-table>
                     </td>
                   </tr>
+
                 </common-table>
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+
               </else-if>
             </for>
           </marko-web-query>
         </td>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
       </tr>
     </common-table>
 

--- a/tenants/all/templates/mbt-product-showcase.marko
+++ b/tenants/all/templates/mbt-product-showcase.marko
@@ -2,10 +2,10 @@ import contentList from "@industrial-media/common/graphql/fragments/content-list
 
 $ const { website } = out.global;
 $ const { newsletter, date } = data;
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;"
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "14px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -16,8 +16,8 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
   "margin-top": "3px !important",
   "line-height": "1.2em",
@@ -83,18 +83,13 @@ $ const teaserStyle = {
                         </td>
                       </tr>
                     </common-table>
-                    <common-table width="20" align="left" padding=0 spacing=0>
-                      <tr>
-                        <td>&nbsp;</td>
-                      </tr>
-                    </common-table>
-                    <common-table width="295" class="right" align="right" padding=0 spacing=0>
+                    <common-table width="295" class="main" align="right" padding=0 spacing=0>
                       <tr>
                         <td>
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
                       </tr>
                     </common-table>

--- a/tenants/all/templates/mbt-today.marko
+++ b/tenants/all/templates/mbt-today.marko
@@ -6,11 +6,11 @@ import GAM from "../config/gam";
 $ const { website } = out.global;
 $ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#23255d";
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;";
 $ const titleStyle = "text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #000000; text-align: left; font-weight: bold;";
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "16px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -21,28 +21,27 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
   "line-height": "1.2em",
 };
 $ const textAdCopyStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "font-size": "12px",
-  color: "#000000",
-  "line-height": "1em",
+  "color": "#000000",
   "text-align": "left",
   "line-height": "18px",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
-  background: "#3B579D",
-  color: "#ffffff",
+  "background": "#3B579D",
+  "color": "#ffffff",
   "font-weight": "bold",
   "font-size": "16px",
   "margin-top": "10px",
@@ -143,10 +142,10 @@ $ const textAdButtonLinkStyle = {
                 </marko-newsletter-imgix>
               </marko-core-obj-value>
 
-              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
-              <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </for>
           </marko-web-query>
         </td>
@@ -195,11 +194,14 @@ $ const textAdButtonLinkStyle = {
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
 
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
                       </tr>
                     </common-table>
                   </for>
@@ -215,7 +217,7 @@ $ const textAdButtonLinkStyle = {
             sectionId: 63328,
             queryFragment: contentList,
           }>
-            <!-- Left Wrapping Table -->
+            <!-- Right Wrapping Table -->
             <common-table width="300" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
               <tr>
                 <td valign="top">
@@ -249,7 +251,9 @@ $ const textAdButtonLinkStyle = {
                               </td>
                             </tr>
                           </common-table>
-                          <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
+                          <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
                           <common-table align="right" class="main" padding=0 spacing=0>
                             <tr>
                               <td style=`${textAdButtonStyle}`>
@@ -275,9 +279,7 @@ $ const textAdButtonLinkStyle = {
 
         </td>
       </tr>
-      <tr>
-        <td>&nbsp;</td>
-      </tr>
+
       <tr>
         <td><hr></td>
       </tr>
@@ -324,7 +326,7 @@ $ const textAdButtonLinkStyle = {
                       <marko-core-obj-text obj=node field="name" >
                         <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                       </marko-core-obj-text>
-                      <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                     </td>
                   </tr>
                   <tr>
@@ -334,66 +336,61 @@ $ const textAdButtonLinkStyle = {
               </if>
               <else-if(node.type === 'text-ad')>
                 <!-- Left Wrapping Table -->
-                <common-table width="630" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
+
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
                   <tr>
-                    <td valign="top">
-                      <common-table width="630" style="border-collapse:collapse;" align="left" class="right" padding=10 spacing=0>
+                    <td bgcolor="#ecedee">
+                      <marko-core-obj-text obj=node field="name">
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <common-table
+                        style="margin:10px 10px 0 0;"
+                        align="left"
+                        class="left"
+                        padding=5
+                        spacing=0
+                      >
                         <tr>
-                          <td bgcolor="#ecedee">
-                            <marko-core-obj-text obj=node field="name">
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-                            <common-table
-                              style="margin:10px 10px 0 0;"
-                              align="left"
-                              class="left"
-                              padding=0
-                              spacing=0
-                            >
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 150 }
-                                      class="main"
-                                      attrs={ border: 0, width: 150 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
-                            <common-table align="right" class="main" padding=0 spacing=0>
-                              <tr>
-                                <td style=`${textAdButtonStyle}`>
-                                  <marko-core-obj-text obj=node field="linkText" html=true >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
-                                  </marko-core-obj-text>
-                                </td>
-                              </tr>
-                            </common-table>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options={ w: 150 }
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
                           </td>
                         </tr>
                       </common-table>
-                      <common-table width="100%" align="center" class="center" >
+
+                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                      <common-table align="right" class="main" padding=0 spacing=0>
                         <tr>
-                          <td>&nbsp;</td>
+                          <td style=`${textAdButtonStyle}`>
+                            <marko-core-obj-text obj=node field="linkText" html=true >
+                              <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                            </marko-core-obj-text>
+                          </td>
                         </tr>
                       </common-table>
                     </td>
                   </tr>
+
                 </common-table>
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+
               </else-if>
             </for>
           </marko-web-query>
         </td>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
       </tr>
     </common-table>
 

--- a/tenants/all/templates/newswire.marko
+++ b/tenants/all/templates/newswire.marko
@@ -6,11 +6,11 @@ import GAM from "../config/gam";
 $ const { website } = out.global;
 $ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#c93a3a";
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;";
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;";
 $ const titleStyle = "text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #000000; text-align: left; font-weight: bold;";
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "16px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -21,28 +21,27 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
   "line-height": "1.2em",
 };
 $ const textAdCopyStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "font-size": "12px",
-  color: "#000000",
-  "line-height": "1em",
+  "color": "#000000",
   "text-align": "left",
   "line-height": "18px",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
-  background: "#3B579D",
-  color: "#ffffff",
+  "background": "#3B579D",
+  "color": "#ffffff",
   "font-weight": "bold",
   "font-size": "16px",
   "margin-top": "10px",
@@ -143,10 +142,10 @@ $ const textAdButtonLinkStyle = {
                 </marko-newsletter-imgix>
               </marko-core-obj-value>
 
-              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
-              <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </for>
           </marko-web-query>
         </td>
@@ -195,11 +194,14 @@ $ const textAdButtonLinkStyle = {
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
 
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
                       </tr>
                     </common-table>
                   </for>
@@ -215,7 +217,7 @@ $ const textAdButtonLinkStyle = {
             sectionId: 63412,
             queryFragment: contentList,
           }>
-            <!-- Left Wrapping Table -->
+            <!-- Right Wrapping Table -->
             <common-table width="300" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
               <tr>
                 <td valign="top">
@@ -249,7 +251,9 @@ $ const textAdButtonLinkStyle = {
                               </td>
                             </tr>
                           </common-table>
-                          <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
+                          <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
                           <common-table align="right" class="main" padding=0 spacing=0>
                             <tr>
                               <td style=`${textAdButtonStyle}`>
@@ -275,9 +279,7 @@ $ const textAdButtonLinkStyle = {
 
         </td>
       </tr>
-      <tr>
-        <td>&nbsp;</td>
-      </tr>
+
       <tr>
         <td><hr></td>
       </tr>
@@ -324,7 +326,7 @@ $ const textAdButtonLinkStyle = {
                       <marko-core-obj-text obj=node field="name" >
                         <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                       </marko-core-obj-text>
-                      <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                     </td>
                   </tr>
                   <tr>
@@ -334,66 +336,61 @@ $ const textAdButtonLinkStyle = {
               </if>
               <else-if(node.type === 'text-ad')>
                 <!-- Left Wrapping Table -->
-                <common-table width="630" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
+
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
                   <tr>
-                    <td valign="top">
-                      <common-table width="630" style="border-collapse:collapse;" align="left" class="right" padding=10 spacing=0>
+                    <td bgcolor="#ecedee">
+                      <marko-core-obj-text obj=node field="name">
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <common-table
+                        style="margin:10px 10px 0 0;"
+                        align="left"
+                        class="left"
+                        padding=5
+                        spacing=0
+                      >
                         <tr>
-                          <td bgcolor="#ecedee">
-                            <marko-core-obj-text obj=node field="name">
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-                            <common-table
-                              style="margin:10px 10px 0 0;"
-                              align="left"
-                              class="left"
-                              padding=0
-                              spacing=0
-                            >
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 150 }
-                                      class="main"
-                                      attrs={ border: 0, width: 150 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <marko-core-obj-text tag="p" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
-                            <common-table align="right" class="main" padding=0 spacing=0>
-                              <tr>
-                                <td style=`${textAdButtonStyle}`>
-                                  <marko-core-obj-text obj=node field="linkText" html=true >
-                                    <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
-                                  </marko-core-obj-text>
-                                </td>
-                              </tr>
-                            </common-table>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options={ w: 150 }
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
                           </td>
                         </tr>
                       </common-table>
-                      <common-table width="100%" align="center" class="center" >
+
+                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                      <common-table align="right" class="main" padding=0 spacing=0>
                         <tr>
-                          <td>&nbsp;</td>
+                          <td style=`${textAdButtonStyle}`>
+                            <marko-core-obj-text obj=node field="linkText" html=true >
+                              <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                            </marko-core-obj-text>
+                          </td>
                         </tr>
                       </common-table>
                     </td>
                   </tr>
+
                 </common-table>
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+
               </else-if>
             </for>
           </marko-web-query>
         </td>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
       </tr>
     </common-table>
 

--- a/tenants/ien/templates/ien-today.marko
+++ b/tenants/ien/templates/ien-today.marko
@@ -4,11 +4,11 @@ import emailX from "../config/email-x";
 $ const { website } = out.global;
 $ const { newsletter, date } = data;
 $ const primaryColor = "#ee0228";
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;"
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
 $ const titleStyle = "text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #000000; text-align: left; font-weight: bold;";
 $ const contentLinkStyle = {
   "text-decoration": "none",
-   "text-align": "left",
+  "text-align": "left",
   "text-decoration": "none !important",
   "font-size": "16px",
   "font-family": "Arial, Helvetica, sans-serif",
@@ -19,27 +19,26 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
   "line-height": "1.2em",
 };
 $ const textAdCopyStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
-  "font-size": "12px",
-  color: "#000000",
-  "line-height": "1em",
+  "font-size": "13px",
+  "color": "#000000",
   "text-align": "left",
   "line-height": "18px",
-  "margin-top": "3px !important",
+  "margin-top": "5px !important",
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
   "text-decoration": "none",
   "text-align": "left",
-  background: "#3B579D",
-  color: "#ffffff",
+  "background": "#3B579D",
+  "color": "#ffffff",
   "font-weight": "bold",
   "font-size": "16px",
   "margin-top": "10px",
@@ -106,7 +105,7 @@ $ const textAdButtonLinkStyle = {
       </tr>
     </common-table>
 
-    <!-- Featrued Full -->
+    <!-- Featured Full -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
         <td>
@@ -140,10 +139,10 @@ $ const textAdButtonLinkStyle = {
                 </marko-newsletter-imgix>
               </marko-core-obj-value>
 
-              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+              <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                 <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
               </marko-core-obj-text>
-              <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+              <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
             </for>
           </marko-web-query>
         </td>
@@ -155,7 +154,7 @@ $ const textAdButtonLinkStyle = {
         <td><hr></td>
       </tr>
     </common-table>
-    
+
     <!-- Featured Split Left||Right -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
@@ -193,11 +192,14 @@ $ const textAdButtonLinkStyle = {
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
 
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
                       </tr>
                     </common-table>
                   </for>
@@ -214,7 +216,7 @@ $ const textAdButtonLinkStyle = {
             limit: 2,
             queryFragment: contentList,
           }>
-            <!-- Left Wrapping Table -->
+            <!-- Right Wrapping Table -->
             <common-table width="300" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
               <tr>
                 <td valign="top">
@@ -248,12 +250,14 @@ $ const textAdButtonLinkStyle = {
                               </td>
                             </tr>
                           </common-table>
+
                           <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+
                           <common-table align="right" class="main" padding=0 spacing=0>
                             <tr>
                               <td style=`${textAdButtonStyle}`>
                                 <marko-core-obj-text obj=node field="linkText" html=true >
-                                  <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                                  <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
                                 </marko-core-obj-text>
                               </td>
                             </tr>
@@ -274,9 +278,7 @@ $ const textAdButtonLinkStyle = {
 
         </td>
       </tr>
-      <tr>
-        <td>&nbsp;</td>
-      </tr>
+
       <tr>
         <td><hr></td>
       </tr>
@@ -295,7 +297,6 @@ $ const textAdButtonLinkStyle = {
             date: date.valueOf(),
             newsletterId: newsletter.id,
             sectionId: 52259,
-            limit: 25,
             queryFragment: contentList,
           }>
             <for|node| of=nodes>
@@ -324,7 +325,7 @@ $ const textAdButtonLinkStyle = {
                       <marko-core-obj-text obj=node field="name" >
                         <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                       </marko-core-obj-text>
-                      <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                     </td>
                   </tr>
                   <tr>
@@ -334,66 +335,61 @@ $ const textAdButtonLinkStyle = {
               </if>
               <else-if(node.type === 'text-ad')>
                 <!-- Left Wrapping Table -->
-                <common-table width="630" style="border-collapse:collapse;" align="right" class="main" padding=0 spacing=0>
+
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
                   <tr>
-                    <td valign="top">
-                      <common-table width="630" style="border-collapse:collapse;" align="left" class="right" padding=10 spacing=0>
+                    <td bgcolor="#ecedee">
+                      <marko-core-obj-text obj=node field="name">
+                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                      </marko-core-obj-text>
+                      <common-table
+                        style="margin:10px 10px 0 0;"
+                        align="left"
+                        class="left"
+                        padding=5
+                        spacing=0
+                      >
                         <tr>
-                          <td bgcolor="#ecedee">
-                            <marko-core-obj-text obj=node field="name">
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                            </marko-core-obj-text>
-                            <common-table
-                              style="margin:10px 10px 0 0;"
-                              align="left"
-                              class="left"
-                              padding=0
-                              spacing=0
-                            >
-                              <tr>
-                                <td>
-                                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                                    <marko-newsletter-imgix
-                                      src=image.src
-                                      alt=image.alt
-                                      options={ w: 150 }
-                                      class="main"
-                                      attrs={ border: 0, width: 150 }
-                                    >
-                                      <@link href=node.siteContext.url target="_blank" />
-                                    </marko-newsletter-imgix>
-                                  </marko-core-obj-value>
-                                </td>
-                              </tr>
-                            </common-table>
-                            <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
-                            <common-table align="right" class="main" padding=0 spacing=0>
-                              <tr>
-                                <td style=`${textAdButtonStyle}`>
-                                  <marko-core-obj-text obj=node field="linkText" html=true >
-                                    <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
-                                  </marko-core-obj-text>
-                                </td>
-                              </tr>
-                            </common-table>
+                          <td>
+                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                              <marko-newsletter-imgix
+                                src=image.src
+                                alt=image.alt
+                                options={ w: 150 }
+                                class="main"
+                                attrs={ border: 0, width: 150 }
+                              >
+                                <@link href=node.siteContext.url target="_blank" />
+                              </marko-newsletter-imgix>
+                            </marko-core-obj-value>
                           </td>
                         </tr>
                       </common-table>
-                      <common-table width="100%" align="center" class="center" >
+
+                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                      <common-table align="right" class="main" padding=0 spacing=0>
                         <tr>
-                          <td>&nbsp;</td>
+                          <td style=`${textAdButtonStyle}`>
+                            <marko-core-obj-text obj=node field="linkText" html=true >
+                              <@link href=node.linkText target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                            </marko-core-obj-text>
+                          </td>
                         </tr>
                       </common-table>
                     </td>
                   </tr>
+
                 </common-table>
+                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
+                  <tr>
+                    <td>&nbsp;</td>
+                  </tr>
+                </common-table>
+
               </else-if>
             </for>
           </marko-web-query>
         </td>
-      </tr>
-      <tr>
-        <td>&nbsp;</td>
       </tr>
     </common-table>
 

--- a/tenants/ien/templates/product-showcase.marko
+++ b/tenants/ien/templates/product-showcase.marko
@@ -3,7 +3,7 @@ import emailX from "../config/email-x";
 
 $ const { website } = out.global;
 $ const { newsletter, date } = data;
-$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: regular;"
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
 $ const contentLinkStyle = {
   "text-decoration": "none",
    "text-align": "left",
@@ -17,8 +17,8 @@ $ const teaserStyle = {
   "text-decoration": "none !important",
   "font-size": "13px",
   "font-family": "Arial, Helvetica, sans-serif",
-  color: "#666666",
-  "font-weight": "regular",
+  "color": "#666666",
+  "font-weight": "normal",
   "text-align": "left",
   "margin-top": "3px !important",
   "line-height": "1.2em",
@@ -86,18 +86,13 @@ $ const teaserStyle = {
                         </td>
                       </tr>
                     </common-table>
-                    <common-table width="20" align="left" padding=0 spacing=0>
-                      <tr>
-                        <td>&nbsp;</td>
-                      </tr>
-                    </common-table>
-                    <common-table width="295" class="right" align="right" padding=0 spacing=0>
+                    <common-table width="295" class="main" align="right" padding=0 spacing=0>
                       <tr>
                         <td>
-                          <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "10px", "text-align": "left" } } >
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
                             <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
                           </marko-core-obj-text>
-                          <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
                         </td>
                       </tr>
                     </common-table>


### PR DESCRIPTION
- Removed extra wrapping table around text-ads
- Replaced font-weight: regular with font-weight: normal
- Tweaked spacing to be more consistent between blocks
- Wrapping tag around teaser changed from p to div to inherit styling in outlook

Started with these two issues, then I started finding other stuff and it kinda blew up

 https://southcomm.atlassian.net/browse/BCMS-233
https://southcomm.atlassian.net/browse/BCMS-210

Some screenshots from testing:

![image](https://user-images.githubusercontent.com/12496550/71606581-a46ca280-2b37-11ea-99af-9253dceff4eb.png)

<img width="672" alt="Screen Shot 2019-12-30 at 5 44 53 PM" src="https://user-images.githubusercontent.com/12496550/71606587-b9493600-2b37-11ea-9772-93f6327b8653.png">

<img width="681" alt="Screen Shot 2019-12-30 at 5 35 20 PM" src="https://user-images.githubusercontent.com/12496550/71606588-b9493600-2b37-11ea-97c8-4afe02f28654.png">

<img width="651" alt="Screen Shot 2019-12-30 at 5 35 14 PM" src="https://user-images.githubusercontent.com/12496550/71606589-b9e1cc80-2b37-11ea-8353-f43e555c45a2.png">

<img width="534" alt="Screen Shot 2019-12-30 at 3 19 54 PM" src="https://user-images.githubusercontent.com/12496550/71606590-b9e1cc80-2b37-11ea-99a5-fb77363b0207.png">

