### PR TITLE
Modified spacing around header image

### DIFF
--- a/tenants/all/templates/fm-product-showcase.marko
+++ b/tenants/all/templates/fm-product-showcase.marko
@@ -40,8 +40,10 @@ $ const teaserStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/fm-today.marko
+++ b/tenants/all/templates/fm-today.marko
@@ -64,8 +64,10 @@ $ const textAdButtonLinkStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/id-product-showcase.marko
+++ b/tenants/all/templates/id-product-showcase.marko
@@ -40,8 +40,10 @@ $ const teaserStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/id-today.marko
+++ b/tenants/all/templates/id-today.marko
@@ -65,8 +65,10 @@ $ const textAdButtonLinkStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/impo-mag-product-showcase.marko
+++ b/tenants/all/templates/impo-mag-product-showcase.marko
@@ -40,8 +40,10 @@ $ const teaserStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/impo-mag-today.marko
+++ b/tenants/all/templates/impo-mag-today.marko
@@ -65,8 +65,10 @@ $ const textAdButtonLinkStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/manufacturing-product-showcase.marko
+++ b/tenants/all/templates/manufacturing-product-showcase.marko
@@ -40,8 +40,10 @@ $ const teaserStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/manufacturing-today.marko
+++ b/tenants/all/templates/manufacturing-today.marko
@@ -66,8 +66,10 @@ $ const textAdButtonLinkStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/mbt-product-showcase.marko
+++ b/tenants/all/templates/mbt-product-showcase.marko
@@ -40,8 +40,10 @@ $ const teaserStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/mbt-today.marko
+++ b/tenants/all/templates/mbt-today.marko
@@ -65,8 +65,10 @@ $ const textAdButtonLinkStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/all/templates/newswire.marko
+++ b/tenants/all/templates/newswire.marko
@@ -65,8 +65,10 @@ $ const textAdButtonLinkStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/ien/templates/ien-today.marko
+++ b/tenants/ien/templates/ien-today.marko
@@ -27,7 +27,7 @@ $ const teaserStyle = {
 };
 $ const textAdCopyStyle = {
   "font-family": "Arial, Helvetica, sans-serif",
-  "font-size": "13px",
+  "font-size": "12px",
   "color": "#000000",
   "text-align": "left",
   "line-height": "18px",
@@ -62,8 +62,10 @@ $ const textAdButtonLinkStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/ien/templates/ien-update.marko
+++ b/tenants/ien/templates/ien-update.marko
@@ -21,8 +21,10 @@ $ const { newsletter, date } = data;
 
     <common-table width="630" align="center" class="main" padding=null spacing=null>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")

--- a/tenants/ien/templates/product-showcase.marko
+++ b/tenants/ien/templates/product-showcase.marko
@@ -15,7 +15,7 @@ $ const contentLinkStyle = {
 };
 $ const teaserStyle = {
   "text-decoration": "none !important",
-  "font-size": "13px",
+  "font-size": "12px",
   "font-family": "Arial, Helvetica, sans-serif",
   "color": "#666666",
   "font-weight": "normal",
@@ -42,8 +42,10 @@ $ const teaserStyle = {
     <!-- Header -->
     <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
       <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
         <td>
-          <div style="line-height:20px; font-size:2px;">&nbsp;</div>
           <common-default-header-block
             name=newsletter.name
             href=website.get("origin")


### PR DESCRIPTION
Super small font-sizes can increase their spam score, so I replaced everywhere “font-size:2px” was with an empty <tr><td>