### PR TITLE
Footer link fix + "Link Text" font-family update

### DIFF
--- a/tenants/all/templates/fm-product-showcase.marko
+++ b/tenants/all/templates/fm-product-showcase.marko
@@ -116,9 +116,9 @@ $ const teaserStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/fm-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -160,9 +160,9 @@ $ const teaserStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/fm-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/fm-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/fm-today.marko
+++ b/tenants/all/templates/fm-today.marko
@@ -406,9 +406,9 @@ $ const textAdButtonLinkStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/fm-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -450,9 +450,9 @@ $ const textAdButtonLinkStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/fm-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/fm-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/id-product-showcase.marko
+++ b/tenants/all/templates/id-product-showcase.marko
@@ -118,9 +118,9 @@ $ const teaserStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/id-advertising` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -162,9 +162,9 @@ $ const teaserStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/id-advertising`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/id-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/id-today.marko
+++ b/tenants/all/templates/id-today.marko
@@ -407,9 +407,9 @@ $ const textAdButtonLinkStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/id-advertising` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -451,9 +451,9 @@ $ const textAdButtonLinkStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/id-advertising`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/id-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/id-today.marko
+++ b/tenants/all/templates/id-today.marko
@@ -37,7 +37,6 @@ $ const textAdCopyStyle = {
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
-  "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
   "background": "#3B579D",

--- a/tenants/all/templates/impo-mag-product-showcase.marko
+++ b/tenants/all/templates/impo-mag-product-showcase.marko
@@ -115,9 +115,9 @@ $ const teaserStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/impo-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -159,9 +159,9 @@ $ const teaserStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/impo-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/impo-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/impo-mag-today.marko
+++ b/tenants/all/templates/impo-mag-today.marko
@@ -407,9 +407,9 @@ $ const textAdButtonLinkStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/impo-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -451,9 +451,9 @@ $ const textAdButtonLinkStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/impo-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/impo-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/impo-mag-today.marko
+++ b/tenants/all/templates/impo-mag-today.marko
@@ -37,7 +37,6 @@ $ const textAdCopyStyle = {
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
-  "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
   "background": "#3B579D",

--- a/tenants/all/templates/manufacturing-product-showcase.marko
+++ b/tenants/all/templates/manufacturing-product-showcase.marko
@@ -115,9 +115,9 @@ $ const teaserStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/mnet-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -159,9 +159,9 @@ $ const teaserStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/mnet-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/mnet-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/manufacturing-today.marko
+++ b/tenants/all/templates/manufacturing-today.marko
@@ -37,7 +37,6 @@ $ const textAdCopyStyle = {
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
-  "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
   "background": "#3B579D",

--- a/tenants/all/templates/manufacturing-today.marko
+++ b/tenants/all/templates/manufacturing-today.marko
@@ -408,9 +408,9 @@ $ const textAdButtonLinkStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/mnet-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -452,9 +452,9 @@ $ const textAdButtonLinkStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/mnet-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/mnet-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/mbt-product-showcase.marko
+++ b/tenants/all/templates/mbt-product-showcase.marko
@@ -115,9 +115,9 @@ $ const teaserStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/mbt-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -159,9 +159,9 @@ $ const teaserStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/mbt-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/mbt-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/mbt-today.marko
+++ b/tenants/all/templates/mbt-today.marko
@@ -407,9 +407,9 @@ $ const textAdButtonLinkStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/mbt-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -451,9 +451,9 @@ $ const textAdButtonLinkStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/mbt-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/mbt-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">

--- a/tenants/all/templates/mbt-today.marko
+++ b/tenants/all/templates/mbt-today.marko
@@ -37,7 +37,6 @@ $ const textAdCopyStyle = {
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
-  "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
   "background": "#3B579D",

--- a/tenants/all/templates/newswire.marko
+++ b/tenants/all/templates/newswire.marko
@@ -37,7 +37,6 @@ $ const textAdCopyStyle = {
 };
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
-  "font-family": "Arial, Helvetica, sans-serif",
   "text-decoration": "none",
   "text-align": "left",
   "background": "#3B579D",

--- a/tenants/all/templates/newswire.marko
+++ b/tenants/all/templates/newswire.marko
@@ -407,9 +407,9 @@ $ const textAdButtonLinkStyle = {
                   |
                   <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
                   |
-                  <a href=`${website.get("origin")}/subscribe/email` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
                   |
-                  <a href=`${website.get("origin")}/advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
+                  <a href=`${website.get("origin")}/page/mnet-advertise` target="_blank" style=`${blackBarText}`>Advertise</a>
                 </div>
               </td>
             </tr>
@@ -451,9 +451,9 @@ $ const textAdButtonLinkStyle = {
               <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
               | <a href="%%ftaf_url%%">Forward to a Friend</a>
               | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
-              | <a href=`${website.get("origin")}/advertise`>Advertise</a>
+              | <a href=`${website.get("origin")}/page/mnet-advertise`>Advertise</a>
               | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
-              | <a href=`${website.get("origin")}/privacy-policy`> Privacy Policy</a>
+              | <a href=`${website.get("origin")}/page/mnet-privacy-policy`> Privacy Policy</a>
             </p>
 
             <p style="margin:0px;margin-bottom:1em;">


### PR DESCRIPTION
Fixed the links in the footers of the new eNLs that were 404ing (Advertise, Subscribe, Privacy-policy).

It was also requested that the "Link Text" font matches IENs, which is actually just the browser default serif font-family, so I removed the sans-serif font-family specification override for Link Text:

![Screen Shot 2020-01-21 at 3 07 12 PM](https://user-images.githubusercontent.com/12496550/72844265-c43c4580-3c61-11ea-8434-d4e4784ef277.png)

To match IEN:
![Screen Shot 2020-01-21 at 3 07 00 PM](https://user-images.githubusercontent.com/12496550/72844264-c2728200-3c61-11ea-80fa-30c0f1f64965.png)

