### PR TITLE
Digital Edition for ID

### DIFF
--- a/packages/common/graphql/fragments/latest-issue.js
+++ b/packages/common/graphql/fragments/latest-issue.js
@@ -1,0 +1,22 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazinePublicationCardLatestIssueFragment on MagazineIssue {
+  id
+  name
+  digitalEditionUrl
+  canonicalPath
+  coverImage {
+    id
+    src
+  }
+  publication {
+    id
+    name
+    subscribeUrl
+    canonicalPath
+  }
+}
+
+`;

--- a/packages/common/graphql/fragments/latest-issue.js
+++ b/packages/common/graphql/fragments/latest-issue.js
@@ -2,7 +2,7 @@ const gql = require('graphql-tag');
 
 module.exports = gql`
 
-fragment MagazinePublicationCardLatestIssueFragment on MagazineIssue {
+fragment MagazinePublicationLatestIssueFragment on MagazineIssue {
   id
   name
   digitalEditionUrl

--- a/tenants/all/templates/id-digital-edition.marko
+++ b/tenants/all/templates/id-digital-edition.marko
@@ -1,0 +1,257 @@
+import contentList from "@industrial-media/common/graphql/fragments/content-list";
+import latestIssueFragment from "@industrial-media/common/graphql/fragments/latest-issue";
+
+$ const { website } = out.global;
+$ const { newsletter, date, dateInfo } = data;
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
+$ const contentLinkStyle = {
+  "text-align": "left",
+  "text-decoration": "none !important",
+  "font-size": "14px",
+  "font-family": "Arial, Helvetica, sans-serif",
+  "color": "#f06724",
+  "font-weight": "bold"
+};
+$ const teaserStyle = {
+  "text-decoration": "none !important",
+  "font-size": "13px",
+  "font-family": "Arial, Helvetica, sans-serif",
+  "color": "#666666",
+  "font-weight": "normal",
+  "text-align": "left",
+  "margin-top": "3px !important",
+  "line-height": "1.2em",
+};
+
+<marko-newsletter-root
+  title=newsletter.n
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;">
+    <tenant-banner-element
+      newsletter=newsletter
+      date=date
+      date-info=dateInfo
+    />
+
+<!-- Header -->
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" spacing=0 padding=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>
+          <common-default-header-block
+            name=newsletter.name
+            href=website.get("origin")
+            image-src="/files/base/indm/all/image/static/logos/id-logo.png"
+            bg-color="#ffffff"
+          />
+        </td>
+      </tr>
+    </common-table>
+
+    <common-table width="630" border="0" align="center" class="main" spacing=0 padding=0>
+      <tr style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #f06724; font-weight: bold;">
+        <td bgcolor="#f06724" style="font-size: 13px; font-weight: bold; color:#ffffff" width="100%" height="25" align="center" valign="middle">
+          The ${date.format("MMMM D, Y")} Digital Edition is here!
+        </td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+    </common-table>
+
+<!-- Digital Edition Cover -->
+    <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+      <tr>
+        <td>
+
+
+          <marko-web-query|{ node: issue }| name="magazine-latest-issue" params={
+            publicationId: "5dd31636b1e3fe2e008b46ae",
+            queryFragment: latestIssueFragment
+          }>
+
+            <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+              <tr>
+                <td valign="top" align="center">
+                    <marko-core-obj-value|{ value: coverImage }| obj=issue field="coverImage" as="object">
+                      <marko-newsletter-imgix
+                        src=coverImage.src
+                        alt=coverImage.alt
+                        options={ w: 450 }
+                        class="main"
+                        attrs={ border: 0, width: 450 }
+                      >
+                        <@link href=issue.digitalEditionUrl  target="_blank" />
+                      </marko-newsletter-imgix>
+                    </marko-core-obj-value>
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+
+          </marko-web-query>
+        </td>
+      </tr>
+    </common-table>
+    <common-table width="630" padding=0 spacing=0 align="center" style="border-collapse:collapse;" class="main">
+      <tr>
+        <td><hr>&nbsp;</td>
+      </tr>
+    </common-table>
+<!-- Body/Sections -->
+    <common-table width="630" border="0" spacing=0 padding=10 align="center" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ee0228; font-weight: bold; border-collapse:collapse;" class="main">
+      <tr>
+        <td bgcolor="#000000" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; text-align: left; font-weight: bold;">
+          NEW FROM INDUSTRIAL DISTRIBUTION
+        </td>
+      </tr>
+    </common-table>
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>
+          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+            date: date.valueOf(),
+            newsletterId: newsletter.id,
+            sectionId: 63788,
+            queryFragment: contentList,
+          }>
+          <for|node| of=nodes>
+            <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+              <tr>
+                <td valign="top">
+                  <common-table border="0" spacing=0 padding=0 align="left" class="main">
+                    <tr>
+                        <td>
+                          <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                            <marko-newsletter-imgix
+                              src=image.src
+                              alt=image.alt
+                              options={ w: 150 }
+                              class="main"
+                              attrs={ border: 0, width: 150 }
+                            >
+                              <@link href=node.siteContext.url target="_blank" />
+                            </marko-newsletter-imgix>
+                          </marko-core-obj-value>
+                        </td>
+                    </tr>
+                  </common-table>
+                  <common-table width="460" border="0" spacing=0 padding=0 align="right" class="main">
+                    <tr>
+                      <td>
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+                            <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                          </marko-core-obj-text>
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      </td>
+                    </tr>
+                  </common-table>
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+          </for>
+
+          </marko-web-query>
+        </td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+    </common-table>
+
+<!-- Footer/Opt-out -->
+    <common-table width=630 border=0 padding=10 spacing=0 align="center" class="main">
+      <tr>
+        <td bgcolor="#000000">
+          <common-table width=300 border=0 padding=0 spacing=0 align="left">
+            <tr>
+              <td>
+                <div style=`${blackBarText} background-color: #000000; text-align:left;" class="center`>
+                  <a href=`${website.get("origin")}` target="_blank" style=`${blackBarText}`>Home</a>
+                  |
+                  <a href=`${website.get("origin")}/contact-us` target="_blank" style=`${blackBarText}`>Contact Us</a>
+                  |
+                  <a href=`${website.get("origin")}/subscribe` target="_blank" style=`${blackBarText}`>Subscribe</a>
+                  |
+                  <a href=`${website.get("origin")}/page/id-advertising` target="_blank" style=`${blackBarText}`>Advertise</a>
+                </div>
+              </td>
+            </tr>
+          </common-table>
+          <common-table width=300 border=0 padding=0 spacing=0 align="right">
+            <tr>
+              <td>
+                <div style=`${blackBarText}; background-color: #000000; text-align:right;` class="center">© 2019 All rights reserved, Industrial Media, LLC </div>
+              </td>
+            </tr>
+          </common-table>
+        </td>
+      </tr>
+    </common-table>
+    <common-table width=630 border=0 padding=10 spacing=0 align="center" class="main">
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>
+          <span style="display:none;">
+            $!{`
+              %%[
+                set @publistID = listid
+                if IndexOf(_listname,"VPL") > 0 AND IndexOf(_listname,"for List") > 0 then
+                  set @publistID = Substring(_listname,Add(IndexOf(_listname,"for List"),9),20)
+                endif
+              ]%%
+            `}
+          </span>
+          <div style="font-family: Arial, Helvetica, sans-serif; font-size: 10px; line-height: 17px;">
+            <p style="margin:0px;margin-bottom:1em;">This email is being sent to
+              <a href="mailto:%%emailaddr%%">%%emailaddr%%</a>.
+            </p>
+            <p style="margin:0px;margin-bottom:1em;">
+              Please add reply.ien.com to your address book or safe sender list to receive our emails in your inbox.
+            </p>
+            <p style="margin:0px;margin-bottom:1em;">
+              <a href="%%=RedirectTo(CloudPagesURL(204, 'sk', _subscriberkey, 'p', listid, 'ln', _listname, 'j', jobid, 'e', _emailid, 'en', emailname_, 'de', _DataSourceName))=%%">Unsubscribe</a>
+              | <a href="%%ftaf_url%%">Forward to a Friend</a>
+              | <a href="%%profile_center_url%%" alias="Update Profile">Update Profile</a>
+              | <a href=`${website.get("origin")}/page/id-advertising`>Advertise</a>
+              | <a href=`${website.get("origin")}/contact-us`>Customer Service Center </a>
+              | <a href=`${website.get("origin")}/page/id-privacy-policy`> Privacy Policy</a>
+            </p>
+
+            <p style="margin:0px;margin-bottom:1em;">
+              Interested in advertising opportunities?  Please contact <a href="mailto:tom@ien.com">Tom Lynch</a> for more information.
+            </p>
+            <p style="margin:0px;margin-bottom:1em;">
+              If you have trouble with any of these methods, you can reach us at 608-692-2304.
+            </p>
+            <p>
+              %%Member_Busname%% <br>
+              %%Member_Addr%% <br>
+              %%Member_City%%, %%Member_State%%, %%Member_PostalCode%%, %%Member_Country%%
+            </p>
+            <!-- <img border="0" src="https://cdn.baseplatform.io/files/base/newsletter/ien.jpg" width="100" height="100" alt=""/> -->
+            <p>This newsletter is an Industrial Media, LLC product.</p>
+          </div>
+        </td>
+      </tr>
+    </common-table>
+    <marko-newsletters-mc-open-counter />
+  </@body>
+</marko-newsletter-root>

--- a/tenants/all/templates/id-digital-edition.marko
+++ b/tenants/all/templates/id-digital-edition.marko
@@ -70,9 +70,7 @@ $ const teaserStyle = {
     <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
       <tr>
         <td>
-
-
-          <marko-web-query|{ node: issue }| name="magazine-latest-issue" params={
+          <marko-web-query|{ node: latestIssue }| name="magazine-latest-issue" params={
             publicationId: "5dd31636b1e3fe2e008b46ae",
             queryFragment: latestIssueFragment
           }>
@@ -80,17 +78,49 @@ $ const teaserStyle = {
             <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
               <tr>
                 <td valign="top" align="center">
-                    <marko-core-obj-value|{ value: coverImage }| obj=issue field="coverImage" as="object">
-                      <marko-newsletter-imgix
-                        src=coverImage.src
-                        alt=coverImage.alt
-                        options={ w: 450 }
-                        class="main"
-                        attrs={ border: 0, width: 450 }
-                      >
-                        <@link href=issue.digitalEditionUrl  target="_blank" />
-                      </marko-newsletter-imgix>
-                    </marko-core-obj-value>
+                  <marko-core-obj-value|{ value: coverImage }| obj=latestIssue field="coverImage" as="object">
+                    <marko-newsletter-imgix
+                      src=coverImage.src
+                      alt=coverImage.alt
+                      options={ w: 450 }
+                      class="main"
+                      attrs={ border: 0, width: 450 }
+                    >
+                      <@link href=latestIssue.digitalEditionUrl  target="_blank" />
+                    </marko-newsletter-imgix>
+                  </marko-core-obj-value>
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+            <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+              <tr>
+                <td valign="top" align="center" style="font-size:14px; text-decoration: none !important; font-family: Arial, Helvetica, sans-serif; color: #666666;">
+                  Your <strong>${latestIssue.name}</strong> issue of <em>Industrial Distribution Magazine</em> is now available online!
+                    <if(latestIssue.digitalEditionUrl)>
+                      <a href=latestIssue.digitalEditionUrl target="_blank" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #f06724;">
+                        <strong>VIEW »</strong>
+                      </a>
+                    </if>
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+              <tr>
+                <td style="font-size: 14px; text-decoration: none !important; font-family: Arial, Helvetica, sans-serif; color: #666666;" align="center">
+                  <if(latestIssue.publication.subscribeUrl)>
+                    <a style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #f06724;" href=latestIssue.publication.subscribeUrl target="_blank" rel="noopener noreferrer">
+                      <strong>SUBSCRIBE</strong>
+                    </a> for more leading edge content from <em>Indsutrial Distribution</em>!
+                  </if>
+                  <else>
+                    <a style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #f06724;" href=`${website.get("origin")}/subscribe` target="_blank" rel="noopener noreferrer">
+                      <strong>SUBSCRIBE</strong>
+                    </a> for more leading edge content from <em>Indsutrial Distribution</em>!
+                  </else>
                 </td>
               </tr>
               <tr>
@@ -99,6 +129,7 @@ $ const teaserStyle = {
             </common-table>
 
           </marko-web-query>
+
         </td>
       </tr>
     </common-table>

--- a/tenants/ien/templates/digital-edition.marko
+++ b/tenants/ien/templates/digital-edition.marko
@@ -98,7 +98,7 @@ $ const teaserStyle = {
             <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
               <tr>
                 <td valign="top" align="center" style="font-size:14px; text-decoration: none !important; font-family: Arial, Helvetica, sans-serif; color: #666666;">
-                  Your <strong>${latestIssue.name}</strong> issue of <em>Industrial Distribution Magazine</em> is now available online!
+                  Your <strong>${latestIssue.name}</strong> issue of <em>IEN Magazine</em> is now available online!
                     <if(latestIssue.digitalEditionUrl)>
                       <a href=latestIssue.digitalEditionUrl target="_blank" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ee0228;">
                         <strong>VIEW »</strong>
@@ -144,7 +144,7 @@ $ const teaserStyle = {
     <common-table width="630" border="0" spacing=0 padding=10 align="center" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ee0228; font-weight: bold; border-collapse:collapse;" class="main">
       <tr>
         <td bgcolor="#000000" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; text-align: left; font-weight: bold;">
-          NEW FROM INDUSTRIAL DISTRIBUTION
+          NEW FROM IEN.COM
         </td>
       </tr>
     </common-table>

--- a/tenants/ien/templates/digital-edition.marko
+++ b/tenants/ien/templates/digital-edition.marko
@@ -1,0 +1,217 @@
+import contentList from "@industrial-media/common/graphql/fragments/content-list";
+import latestIssueFragment from "@industrial-media/common/graphql/fragments/latest-issue";
+
+$ const { website } = out.global;
+$ const { newsletter, date, dateInfo } = data;
+$ const blackBarText = "text-decoration: none !important; font-size: 10px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; font-weight: normal;"
+$ const contentLinkStyle = {
+  "text-align": "left",
+  "text-decoration": "none !important",
+  "font-size": "14px",
+  "font-family": "Arial, Helvetica, sans-serif",
+  "color": "#ee0228",
+  "font-weight": "bold"
+};
+$ const teaserStyle = {
+  "text-decoration": "none !important",
+  "font-size": "13px",
+  "font-family": "Arial, Helvetica, sans-serif",
+  "color": "#666666",
+  "font-weight": "normal",
+  "text-align": "left",
+  "margin-top": "3px !important",
+  "line-height": "1.2em",
+};
+
+<marko-newsletter-root
+  title=newsletter.n
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important;">
+    <common-banner-element
+      name=newsletter.name
+      date=date
+    />
+<!-- Header -->
+
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" spacing=0 padding=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>
+          <common-default-header-block
+            name=newsletter.name
+            href=website.get("origin")
+            image-src="/files/base/indm/ien/image/2019/01/digital_logo.5c33bcf94cfe7.png"
+            bg-color="#ffffff"
+          />
+        </td>
+      </tr>
+    </common-table>
+
+    <common-table width="630" border="0" align="center" class="main" spacing=0 padding=0>
+      <tr style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ee0228; font-weight: bold;">
+        <td bgcolor="#ee0228" style="font-size: 13px; font-weight: bold; color:#ffffff" width="100%" height="25" align="center" valign="middle">
+          The ${date.format("MMMM D, Y")} Digital Edition is here!
+        </td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+    </common-table>
+
+<!-- Digital Edition Cover -->
+
+    <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+      <tr>
+        <td>
+          <marko-web-query|{ node: latestIssue }| name="magazine-latest-issue" params={
+            publicationId: "5dd31636b1e3fe2e008b46ae",
+            queryFragment: latestIssueFragment
+          }>
+
+            <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+              <tr>
+                <td valign="top" align="center">
+                  <marko-core-obj-value|{ value: coverImage }| obj=latestIssue field="coverImage" as="object">
+                    <marko-newsletter-imgix
+                      src=coverImage.src
+                      alt=coverImage.alt
+                      options={ w: 450 }
+                      class="main"
+                      attrs={ border: 0, width: 450 }
+                    >
+                      <@link href=latestIssue.digitalEditionUrl  target="_blank" />
+                    </marko-newsletter-imgix>
+                  </marko-core-obj-value>
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+            <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+              <tr>
+                <td valign="top" align="center" style="font-size:14px; text-decoration: none !important; font-family: Arial, Helvetica, sans-serif; color: #666666;">
+                  Your <strong>${latestIssue.name}</strong> issue of <em>Industrial Distribution Magazine</em> is now available online!
+                    <if(latestIssue.digitalEditionUrl)>
+                      <a href=latestIssue.digitalEditionUrl target="_blank" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ee0228;">
+                        <strong>VIEW »</strong>
+                      </a>
+                    </if>
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+              <tr>
+                <td style="font-size: 14px; text-decoration: none !important; font-family: Arial, Helvetica, sans-serif; color: #666666;" align="center">
+                  <if(latestIssue.publication.subscribeUrl)>
+                    <a style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ee0228;" href=latestIssue.publication.subscribeUrl target="_blank" rel="noopener noreferrer">
+                      <strong>SUBSCRIBE</strong>
+                    </a> for more leading edge content from <em>Indsutrial Distribution</em>!
+                  </if>
+                  <else>
+                    <a style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ee0228;" href=`${website.get("origin")}/subscribe` target="_blank" rel="noopener noreferrer">
+                      <strong>SUBSCRIBE</strong>
+                    </a> for more leading edge content from <em>Indsutrial Distribution</em>!
+                  </else>
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+
+          </marko-web-query>
+
+        </td>
+      </tr>
+    </common-table>
+    <common-table width="630" padding=0 spacing=0 align="center" style="border-collapse:collapse;" class="main">
+      <tr>
+        <td><hr>&nbsp;</td>
+      </tr>
+    </common-table>
+
+<!-- Body/Sections -->
+
+    <common-table width="630" border="0" spacing=0 padding=10 align="center" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ee0228; font-weight: bold; border-collapse:collapse;" class="main">
+      <tr>
+        <td bgcolor="#000000" style="text-decoration: none !important; font-size: 14px; font-family: Arial, Helvetica, sans-serif; color: #ffffff; text-align: left; font-weight: bold;">
+          NEW FROM INDUSTRIAL DISTRIBUTION
+        </td>
+      </tr>
+    </common-table>
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <td>
+          <marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+            date: date.valueOf(),
+            newsletterId: newsletter.id,
+            sectionId: 61600,
+            queryFragment: contentList,
+          }>
+          <for|node| of=nodes>
+            <common-table width="630" border="0" spacing=0 padding=0 align="center" style="border-collapse:collapse;" class="main">
+              <tr>
+                <td valign="top">
+                  <common-table border="0" spacing=0 padding=0 align="left" class="main">
+                    <tr>
+                        <td>
+                          <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                            <marko-newsletter-imgix
+                              src=image.src
+                              alt=image.alt
+                              options={ w: 150 }
+                              class="main"
+                              attrs={ border: 0, width: 150 }
+                            >
+                              <@link href=node.siteContext.url target="_blank" />
+                            </marko-newsletter-imgix>
+                          </marko-core-obj-value>
+                        </td>
+                    </tr>
+                  </common-table>
+                  <common-table width="460" border="0" spacing=0 padding=0 align="right" class="main">
+                    <tr>
+                      <td>
+                          <marko-core-obj-text obj=node field="name" attrs={ style: { "text-align": "left" } } >
+                            <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                          </marko-core-obj-text>
+                          <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                      </td>
+                    </tr>
+                  </common-table>
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+          </for>
+
+          </marko-web-query>
+        </td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+    </common-table>
+
+<!-- Footer/OptOut -->
+
+    <common-default-footer-block />
+
+    <marko-newsletters-mc-open-counter />
+
+  </@body>
+</marko-newsletter-root>


### PR DESCRIPTION
![Screen Shot 2020-02-27 at 8 40 11 AM](https://user-images.githubusercontent.com/12496550/75926140-a270d980-5e2f-11ea-9a72-88bbd9a9b642.png)

Added some subscribe/digital edition info below cover:
![Screen Shot 2020-03-05 at 11 52 10 AM](https://user-images.githubusercontent.com/12496550/76010235-2f6f6d80-5ed8-11ea-87ae-4df0e0b65500.png)

I think certain things can be cleaned up quite a bit, like the style tags and fallback logic for urls being put in as a util, but I haven't been able to get those to work, so in the interest of time I left them as-is for now.   I'll have to circle back and clean it up when I figure out what I'm doing wrong.  