### PR TITLE
Switch IEN to GAM

### DIFF
--- a/tenants/ien/components/ad-unit.marko
+++ b/tenants/ien/components/ad-unit.marko
@@ -1,0 +1,37 @@
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import emailX from "../config/email-x";
+import GAM from "../config/gam";
+
+$ const { req } = out.global;
+$ const emailXEnabled = Object.hasOwnProperty.call(req.query, 'emailx');
+
+$ const {
+  name,
+  newsletter,
+  date,
+  dateInfo,
+} = input;
+
+$ const { alias } = newsletter;
+
+$ let adUnit;
+$ if (emailXEnabled) {
+  adUnit = emailX.getAdUnit({ name, alias })
+} else {
+  adUnit = GAM.getAdUnit({ name, alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) });
+}
+
+<if(adUnit.path || adUnit.id)>
+  <if(emailXEnabled)>
+    <marko-newsletters-email-x-display decoded-params=["email", "send"]>
+      <@ad-unit ...adUnit />
+      <@params date=date email="%%emailaddr%%" send="%%jobid%%" />
+    </marko-newsletters-email-x-display>
+  </if>
+  <else>
+    <marko-newsletters-gam-display>
+      <@ad-unit ...adUnit />
+      <@image class="scaleAd" />
+    </marko-newsletters-gam-display>
+  </else>
+</if>

--- a/tenants/ien/components/banner-element.marko
+++ b/tenants/ien/components/banner-element.marko
@@ -1,0 +1,34 @@
+import { getAsObject } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const { req } = out.global;
+$ const emailXEnabled = Object.hasOwnProperty.call(req.query, 'emailx');
+
+$ const { newsletter, date, dateInfo } = input;
+
+<common-table width="100%" align="center" class="top">
+  <tr>
+    <td bgcolor="#ecedee">
+      <common-table width="630" align="center" class="main">
+        <tr>
+          <common-view-online-element name=newsletter.name />
+        </tr>
+        <tr>
+          <td align="center">
+            <div class="advertisement inline ad-600x100">
+              <tenant-ad-unit
+                name="header"
+                newsletter=newsletter
+                date=date
+                date-info=dateInfo
+              />
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td height="20" class="short">&nbsp;</td>
+        </tr>
+      </common-table>
+    </td>
+  </tr>
+</common-table>

--- a/tenants/ien/components/marko.json
+++ b/tenants/ien/components/marko.json
@@ -1,1 +1,8 @@
-{}
+{
+  "<tenant-banner-element>": {
+    "template": "./banner-element.marko"
+  },
+  "<tenant-ad-unit>": {
+    "template": "ad-unit.marko"
+  }
+}

--- a/tenants/ien/config/gam.js
+++ b/tenants/ien/config/gam.js
@@ -1,0 +1,103 @@
+const GAMConfiguration = require('@base-cms/marko-newsletters-gam/config');
+
+const config = new GAMConfiguration('137873098');
+
+config
+  .setAdUnits('ien-today', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('ien-weekly', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('video-showcase', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('product-showcase', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('industrial-technology-today', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('industrial-software-technology', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('industrial-management-today', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('food-beverage-insider', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('finishing-world', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('industrial-technology-today', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('engineering-news-today', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ])
+  .setAdUnits('ien-update', [
+    {
+      name: 'header',
+      path: 'IEN-Newsletters-600x100',
+      width: 600,
+      height: 100,
+    },
+  ]);
+
+module.exports = config;

--- a/tenants/ien/templates/engineering-news-today.marko
+++ b/tenants/ien/templates/engineering-news-today.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
 $ const { website } = out.global;
-$ const { newsletter, date } = data;
+$ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#45ad35";
 
 <marko-newsletter-root
@@ -17,7 +18,7 @@ $ const primaryColor = "#45ad35";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/finishing-world.marko
+++ b/tenants/ien/templates/finishing-world.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
-$ const { website, config } = out.global;
-$ const { newsletter, date } = data;
+$ const { website } = out.global;
+$ const { newsletter, date, dateInfo } = data;
 
 $ const socialMediaProviders = config.getAsArray('socialMediaLinks');
 $ const primaryColor = "#2f51a4";
@@ -19,7 +20,7 @@ $ const primaryColor = "#2f51a4";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/food-beverage-insider.marko
+++ b/tenants/ien/templates/food-beverage-insider.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
 $ const { website } = out.global;
-$ const { newsletter, date } = data;
+$ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#ee0228";
 
 <marko-newsletter-root
@@ -17,7 +18,7 @@ $ const primaryColor = "#ee0228";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/ien-today.marko
+++ b/tenants/ien/templates/ien-today.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
 $ const { website } = out.global;
-$ const { newsletter, date } = data;
+$ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#ee0228";
 
 <marko-newsletter-root
@@ -17,7 +18,7 @@ $ const primaryColor = "#ee0228";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/ien-update.marko
+++ b/tenants/ien/templates/ien-update.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
-$ const { website, config } = out.global;
-$ const { newsletter, date } = data;
+$ const { website } = out.global;
+$ const { newsletter, date, dateInfo } = data;
 $ const socialMediaProviders = config.getAsArray('socialMediaLinks');
 $ const primaryColor = "#ee0228";
 
@@ -18,7 +19,7 @@ $ const primaryColor = "#ee0228";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/ien-weekly.marko
+++ b/tenants/ien/templates/ien-weekly.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
-$ const { website, config } = out.global;
-$ const { newsletter, date } = data;
+$ const { website } = out.global;
+$ const { newsletter, date, dateInfo } = data;
 $ const socialMediaProviders = config.getAsArray('socialMediaLinks');
 $ const primaryColor = "#ee0228";
 
@@ -18,7 +19,7 @@ $ const primaryColor = "#ee0228";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/industrial-management-today.marko
+++ b/tenants/ien/templates/industrial-management-today.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
 $ const { website } = out.global;
-$ const { newsletter, date } = data;
+$ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#45ad35";
 
 <marko-newsletter-root
@@ -17,7 +18,7 @@ $ const primaryColor = "#45ad35";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/industrial-software-technology.marko
+++ b/tenants/ien/templates/industrial-software-technology.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
 $ const { website } = out.global;
-$ const { newsletter, date } = data;
+$ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#45ad35";
 
 <marko-newsletter-root
@@ -17,7 +18,7 @@ $ const primaryColor = "#45ad35";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/industrial-technology-today.marko
+++ b/tenants/ien/templates/industrial-technology-today.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
 $ const { website } = out.global;
-$ const { newsletter, date } = data;
+$ const { newsletter, date, dateInfo } = data;
 $ const primaryColor = "#45ad35";
 
 <marko-newsletter-root
@@ -17,7 +18,7 @@ $ const primaryColor = "#45ad35";
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/product-showcase.marko
+++ b/tenants/ien/templates/product-showcase.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
 $ const { website } = out.global;
-$ const { newsletter, date } = data;
+$ const { newsletter, date, dateInfo } = data;
 $ const contentLinkStyle = {
   "text-decoration": "none",
    "text-align": "left",
@@ -35,7 +36,7 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->

--- a/tenants/ien/templates/video-showcase.marko
+++ b/tenants/ien/templates/video-showcase.marko
@@ -1,8 +1,9 @@
 import contentList from "@industrial-media/common/graphql/fragments/content-list";
-import emailX from "../config/email-x";
+import buildGAMTargeting from "@industrial-media/common/utils/build-gam-targeting";
+import GAM from "../config/gam";
 
 $ const { website } = out.global;
-$ const { newsletter, date } = data;
+$ const { newsletter, date, dateInfo } = data;
 
 $ const contentLinkStyle = {
   "text-decoration": "none !important",
@@ -33,7 +34,7 @@ $ const teaserStyle = {
     <common-banner-element
       name=newsletter.name
       date=date
-      ad-unit=emailX.getAdUnit({ name: "header", alias: newsletter.alias })
+      ad-unit=GAM.getAdUnit({ name: "header", alias: newsletter.alias, targeting: buildGAMTargeting({ newsletter, date, dateInfo }) })
     />
 
 <!-- Header -->


### PR DESCRIPTION
Didn’t notice that support for GAM was setup; switched them from emailX to GAM, since that’s what they’re currently using in the legacy newsletters

![image](https://user-images.githubusercontent.com/12496550/76849688-decf0d00-6813-11ea-923a-f542278805e1.png)
https://email.ien.com/food-beverage-insider/2019/11/25