### PR TITLE
Round 1 of INDM eNL Redesign

### DIFF
--- a/packages/common/components/blocks/content/feed-full.marko
+++ b/packages/common/components/blocks/content/feed-full.marko
@@ -10,8 +10,11 @@ $ const {
   skip,
   hrBelow,
   primaryColor,
-  showTeaser
+  showTeaser,
+  twoColumn,
 } = input;
+
+$ let counter = 0;
 
 $ const titleStyle = defaultValue(input.titleStyle, {
   "text-decoration": "none !important",
@@ -72,93 +75,158 @@ $ const textAdButtonLinkStyle = {
           </if>
           <tr>
             <td valign="top">
-              <for|node| of=nodes>
+              <for|node, index| of=nodes>
                 <if(node.type !== 'text-ad')>
-                <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
-                  <tr>
-                    <td valign="top">
-                      <common-table style="margin-right: 10px;" align="left" class="left" padding=0 spacing=0>
+                  <if(twoColumn)>
+                    $ counter++;
+                    $ const isEven = counter % 2 === 0;
+                    $ const align = isEven ? 'right' : 'left';
+                    <common-table width="300" style="border-collapse:collapse;" align=align class="main" padding=0 spacing=0>
+                      <tr>
+                        <td>
+
+                          <common-table width="110" style="border-collapse:collapse; margin-bottom: 5px;" align="left" class="main" padding=0 spacing=0>
+                            <tr>
+                              <td>
+                                <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                                  <marko-newsletter-imgix
+                                    src=image.src
+                                    alt=image.alt
+                                    options={ w: 330 }
+                                    class="main"
+                                    attrs={ border: 0, width: 110 }
+                                  >
+                                    <@link href=node.siteContext.url target="_blank" />
+                                  </marko-newsletter-imgix>
+                                </marko-core-obj-value>
+                              </td>
+                            </tr>
+                          </common-table>
+
+                          <common-table width="170" style="border-collapse:collapse;" spacing=0 padding=0 align="right" class="main">
+                            <tr>
+                              <td>
+                                <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "0px", "text-align": "left" } } >
+                                  <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                                </marko-core-obj-text>
+
+                                <if(showTeaser != false)>
+                                  <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                                </if>
+                              </td>
+                            </tr>
+
+                          </common-table>
+
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
+                      </tr>
+                    </common-table>
+
+                    <if(align === 'right')>
+                      <common-table width="630" align="center" class="main" style="border-collapse:collapse;">
                         <tr>
-                          <td>
-                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                              <marko-newsletter-imgix
-                                src=image.src
-                                alt=image.alt
-                                options={ w: 300 }
-                                class="main"
-                                attrs={ border: 0, width: 150 }
-                              >
-                                <@link href=node.siteContext.url target="_blank" />
-                              </marko-newsletter-imgix>
-                            </marko-core-obj-value>
+                          <td valign="top">
+                            <div style="line-height:5px;">&nbsp;</div>
                           </td>
                         </tr>
                       </common-table>
-                      <marko-core-obj-text obj=node field="name" >
-                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                      </marko-core-obj-text>
-                      <if(showTeaser != false)>
-                        <marko-core-obj-text tag="div" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
-                      </if>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>&nbsp;</td>
-                  </tr>
-                </common-table>
-              </if>
-              <else-if(node.type === 'text-ad')>
-                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
-                  <tr>
-                    <td bgcolor="#ecedee">
-                      <marko-core-obj-text obj=node field="name">
-                        <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
-                      </marko-core-obj-text>
-                      <common-table
-                        style="margin:10px 10px 0 0;"
-                        align="left"
-                        class="left"
-                        padding=5
-                        spacing=0
-                      >
-                        <tr>
-                          <td>
-                            <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
-                              <marko-newsletter-imgix
-                                src=image.src
-                                alt=image.alt
-                                options={ w: 300 }
-                                class="sponsored"
-                                attrs={ border: 0, width: 150 }
-                              >
-                                <@link href=node.siteContext.url target="_blank" />
-                              </marko-newsletter-imgix>
-                            </marko-core-obj-value>
-                          </td>
-                        </tr>
-                      </common-table>
+                    </if>
 
-                      <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
-                      <common-table align="right" padding=0 spacing=0>
-                        <tr>
-                          <td style=`${textAdButtonStyle}`>
-                            <marko-core-obj-text obj=node field="linkText" html=true >
-                              <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
-                            </marko-core-obj-text>
-                          </td>
-                        </tr>
-                      </common-table>
-                    </td>
-                  </tr>
+                  </if>
 
-                </common-table>
-                <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=0 spacing=0>
-                  <tr>
-                    <td>&nbsp;</td>
-                  </tr>
-                </common-table>
+                  <else>
+                    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+                      <tr>
+                        <td valign="top">
+                          <common-table style="margin-right: 10px;" align="left" class="left" padding=0 spacing=0>
+                            <tr>
+                              <td>
+                                <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                                  <marko-newsletter-imgix
+                                    src=image.src
+                                    alt=image.alt
+                                    options={ w: 330 }
+                                    class="main"
+                                    attrs={ border: 0, width: 150 }
+                                  >
+                                    <@link href=node.siteContext.url target="_blank" />
+                                  </marko-newsletter-imgix>
+                                </marko-core-obj-value>
+                              </td>
+                            </tr>
+                          </common-table>
+                          <marko-core-obj-text obj=node field="name" >
+                            <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                          </marko-core-obj-text>
+                          <if(showTeaser != false)>
+                            <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                          </if>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>&nbsp;</td>
+                      </tr>
+                    </common-table>
+                  </else>
 
-              </else-if>
+                </if>
+
+                <else-if(node.type === 'text-ad')>
+                  $ counter = 0;
+                  <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=10 spacing=0>
+                    <tr>
+                      <td bgcolor="#ecedee">
+                        <marko-core-obj-text obj=node field="name">
+                          <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                        </marko-core-obj-text>
+                        <common-table
+                          style="margin:10px 15px 0 0;"
+                          align="left"
+                          class="left"
+                          padding=5
+                          spacing=0
+                        >
+                          <tr>
+                            <td>
+                              <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                                <marko-newsletter-imgix
+                                  src=image.src
+                                  alt=image.alt
+                                  options={ w: 300 }
+                                  attrs={ border: 0, width: 150 }
+                                >
+                                  <@link href=node.siteContext.url target="_blank" />
+                                </marko-newsletter-imgix>
+                              </marko-core-obj-value>
+                            </td>
+                          </tr>
+                        </common-table>
+
+                        <marko-core-obj-text tag="div" obj=node field="body" html=true attrs={ style: textAdCopyStyle } />
+                        <common-table align="right" padding=0 spacing=0>
+                          <tr>
+                            <td class="scaleAd center" style=`${textAdButtonStyle}`>
+                              <marko-core-obj-text obj=node field="linkText" html=true >
+                                <@link href=node.siteContext.url target="_blank" attrs={ style: textAdButtonLinkStyle } />
+                              </marko-core-obj-text>
+                            </td>
+                          </tr>
+                        </common-table>
+                      </td>
+                    </tr>
+
+                  </common-table>
+                  <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+                    <tr>
+                      <td valign="top">
+                        <div style="line-height:20px;">&nbsp;</div>
+                      </td>
+                    </tr>
+                  </common-table>
+                </else-if>
               </for>
             </td>
           </tr>

--- a/packages/common/components/blocks/content/feed-full.marko
+++ b/packages/common/components/blocks/content/feed-full.marko
@@ -15,51 +15,36 @@ $ const {
 
 $ const titleStyle = defaultValue(input.titleStyle, {
   "text-decoration": "none !important",
-  "font-size": "14px",
-  "font-family": "Arial, Helvetica, sans-serif",
+  "font" : "bold 14px/16px Arial, Helvetica, sans-serif",
   "color": "#000000",
-  "text-align": "left",
-  "font-weight": "bold",
 });
 
 $ const teaserStyle = defaultValue(input.teaserStyle, {
   "text-decoration": "none !important",
-  "font-size": "13px",
-  "font-family": "Arial, Helvetica, sans-serif",
+  "font" : "normal 13px/15px Arial, Helvetica, sans-serif",
   "color": "#666666",
-  "font-weight": "normal",
-  "text-align": "left",
   "margin-top": "5px !important",
-  "line-height": "1.2em",
 });
 
 $ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
-  "text-decoration": "none",
-  "text-align": "left",
   "text-decoration": "none !important",
-  "font-size": "16px",
-  "font-family": "Arial, Helvetica, sans-serif",
+  "font" : "bold 16px/18px Arial, Helvetica, sans-serif",
   "color": primaryColor,
-  "font-weight": "bold"
 });
 
 $ const textAdCopyStyle = {
-  "font-family": "Arial, Helvetica, sans-serif",
-  "font-size": "12px",
+  "text-decoration": "none !important",
+  "font" : "normal 12px/18px Arial, Helvetica, sans-serif",
   "color": "#000000",
-  "text-align": "left",
-  "line-height": "18px",
-  "margin-top": "5px !important",
+  "margin-top": "10px !important",
 };
 
 $ const textAdButtonStyle = "background:#3B579D; padding-top:10px; padding-left:10px; padding-right:10px; padding-bottom:10px;";
 $ const textAdButtonLinkStyle = {
-  "text-decoration": "none",
-  "text-align": "left",
+  "text-decoration": "none !important",
+  "font" : "bold 16px/18px Arial, Helvetica, sans-serif",
   "background": "#3B579D",
   "color": "#ffffff",
-  "font-weight": "bold",
-  "font-size": "16px",
   "margin-top": "10px",
 };
 

--- a/packages/common/components/blocks/content/grid.marko
+++ b/packages/common/components/blocks/content/grid.marko
@@ -1,0 +1,144 @@
+import getAlignment from "@industrial-media/common/utils/get-alignment";
+import contentList from "@industrial-media/common/graphql/fragments/content-list";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const {
+  newsletter,
+  date,
+  sectionId,
+  title,
+  limit,
+  skip,
+  primaryColor,
+  hrBelow
+} = input;
+
+$ const titleStyle = defaultValue(input.titleStyle, {
+  "text-decoration": "none !important",
+  "font": "bold 14px/16px Arial, Helvetica, sans-serif",
+  "color": "#000000",
+  "text-align": "left",
+});
+
+$ const teaserStyle = defaultValue(input.teaserStyle, {
+  "text-decoration": "none !important",
+  "font": "400 13px/15px Arial, Helvetica, sans-serif",
+  "color": "#666666",
+  "text-align": "left",
+  "margin-top": "5px !important",
+});
+
+$ const bodyStyle = defaultValue(input.bodyStyle, {
+  "text-decoration": "none !important",
+  "color": "#666666",
+  "font": "400 12px/14px Arial, Helvetica, sans-serif",
+  "text-align": "left",
+  "margin-top": "0px !important",
+});
+
+$ const contentLinkStyle = defaultValue(input.contentLinkStyle, {
+  "text-decoration": "none !important",
+  "font": "bold 16px/18px Arial, Helvetica, sans-serif",
+  "text-align": "left",
+  "color": primaryColor,
+});
+
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" params={
+  date: date.valueOf(),
+  newsletterId: newsletter.id,
+  sectionId: sectionId,
+  limit: limit,
+  skip: skip,
+  queryFragment: contentList,
+}>
+  <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+    <if(title)>
+      <tr>
+        <td style=titleStyle>
+          ${title}
+        </td>
+      </tr>
+      <tr>
+        <td>&nbsp;</td>
+      </tr>
+    </if>
+    <tr>
+      <td valign="top">
+        <for|node, index| of=nodes>
+          $ const align = getAlignment(index);
+
+          <if(node.type === "text-ad")>
+            <common-table width="300" style="border-collapse:collapse;" class="main" align=align padding=0 spacing=0>
+              <tr>
+                <td bgcolor="#ecedee" valign="top" style="padding: 0 10px;" align="center">
+                  <div style="text-align: left; color: #6b6b6b; font: 400 11px/16px Helvetica, Arial, sans-serif;">Advertisement</div>
+                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                    <marko-newsletter-imgix
+                      src=image.src
+                      alt=image.alt
+                      options={ w: 280 }
+                      attrs={ border: 0, width: 280 }
+                    >
+                      <@link href=node.siteContext.url target="_blank" />
+                    </marko-newsletter-imgix>
+                  </marko-core-obj-value>
+
+                  <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
+                    <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                  </marko-core-obj-text>
+                  <marko-core-obj-text tag=null obj=node field="body" html=true attrs={ style: bodyStyle } />
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+          </if>
+
+          <else>
+            <common-table width="300" style="border-collapse:collapse;" align=align class="main" padding=0 spacing=0>
+              <tr>
+                <td>
+                  <marko-core-obj-value|{ value: image }| obj=node field="primaryImage" as="object">
+                    <marko-newsletter-imgix
+                      src=image.src
+                      alt=image.alt
+                      options={ w: 330 }
+                      class="main"
+                      attrs={ border: 0, width: 300 }
+                    >
+                      <@link href=node.siteContext.url target="_blank" />
+                    </marko-newsletter-imgix>
+                  </marko-core-obj-value>
+
+                  <marko-core-obj-text obj=node field="name" attrs={ style: { "margin-top": "5px", "text-align": "left" } } >
+                    <@link href=node.siteContext.url target="_blank" attrs={ style: contentLinkStyle } />
+                  </marko-core-obj-text>
+                  <marko-core-obj-text tag="p" obj=node field="teaser" html=true attrs={ style: teaserStyle } />
+                </td>
+              </tr>
+              <tr>
+                <td>&nbsp;</td>
+              </tr>
+            </common-table>
+          </else>
+
+          <if(align === 'right')>
+            <common-table width="630" align="center" class="main" style="border-collapse:collapse;">
+              <tr>
+                <td valign="top">
+                  <div style="line-height:5px;">&nbsp;</div>
+                </td>
+              </tr>
+            </common-table>
+          </if>
+        </for>
+      </td>
+    </tr>
+  <if(hrBelow === true)>
+    <tr>
+      <td><hr></td>
+    </tr>
+  </if>
+  </common-table>
+</marko-web-query>

--- a/packages/common/components/blocks/content/marko.json
+++ b/packages/common/components/blocks/content/marko.json
@@ -33,7 +33,8 @@
       "default-value" : "#eb1b2c"
     },
     "@hr-below": "bool",
-    "@show-teaser": "bool"
+    "@show-teaser": "bool",
+    "@two-column": "bool"
   },
   "<common-featured-full-block>": {
     "template": "./featured-full.marko",
@@ -106,6 +107,42 @@
       "default-value" : "#eb1b2c"
     },
     "@align": "string"
+  },
+  "<common-grid-block>": {
+    "template": "./grid.marko",
+    "@name": "string",
+    "@href": "string",
+    "@image-src": "string",
+    "@date": {
+      "type": "object",
+      "required": true
+    },
+    "@newsletter": {
+      "type": "object",
+      "required": true
+    },
+    "@section-id": {
+      "type": "number",
+      "required": true
+    },
+    "@limit": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@skip": {
+      "type": "number",
+      "default-value": 0
+    },
+    "@title": "string",
+    "@content-link-style": "object",
+    "@title-style": "string",
+    "@teaser-style": "object",
+    "@body-style": "object",
+    "@hr-below": "bool",
+    "@primary-color": {
+      "type" : "string",
+      "default-value" : "#eb1b2c"
+    }
   },
   "<common-promotion-half-block>": {
     "template": "./promotion-half.marko",

--- a/packages/common/components/blocks/footer/index.marko
+++ b/packages/common/components/blocks/footer/index.marko
@@ -1,6 +1,6 @@
 import defaultValue from "@base-cms/marko-core/utils/default-value";
 
-$ const bgColor = defaultValue(input.bgColor, "#000");
+$ const bgColor = defaultValue(input.bgColor, "#000000");
 $ const footerText = defaultValue(input.footerText, {
   "text-decoration": "none !important",
   "color": "#fff",

--- a/packages/common/components/blocks/header/image-full.marko
+++ b/packages/common/components/blocks/header/image-full.marko
@@ -17,7 +17,7 @@ $ const imageWidth = defaultValue(input.imageWidth, 630);
         <common-table width=imageWidth align="left" class="main">
           <tr>
             <td align="left" valign="top">
-              <marko-newsletter-imgix src=input.imageSrc options={ w: imageWidth } alt=input.name class="logoScale" attrs={ border: 0, width: imageWidth }>
+              <marko-newsletter-imgix src=input.imageSrc options={ w: imageWidth } alt=input.name class="main" attrs={ border: 0, width: imageWidth }>
                 <@link href=input.href title=input.name target="_blank" />
               </marko-newsletter-imgix>
             </td>

--- a/packages/common/components/blocks/header/wrapper.marko
+++ b/packages/common/components/blocks/header/wrapper.marko
@@ -33,6 +33,7 @@ $ const dateStyle = defaultValue(input.dateStyle, {
           src="/files/base/newsletter/header-slanted_left.png"
           options={ w: 166, h: 20 }
           alt=""
+          class="mobileBorder"
           attrs={ border: 0, align: "left", width: 166, height: 20 }>
         </marko-newsletter-imgix>
         <marko-newsletter-imgix

--- a/packages/common/components/elements/view-online.marko
+++ b/packages/common/components/elements/view-online.marko
@@ -1,6 +1,6 @@
 <tr>
   <td
-    height="20"
+    height="35"
     align="center"
     valign="middle"
     style="font-family:Arial, Helvetica, sans-serif;font-size:10px;color:#666666;line-height:12px;"

--- a/packages/common/components/static-styles.marko
+++ b/packages/common/components/static-styles.marko
@@ -1,4 +1,5 @@
 <style type="text/css">
+
   .linkColor a {
     color: #000000;
     text-decoration: none;
@@ -6,26 +7,25 @@
 
   .body h3,
   .body h3 a {
-    font-size: 28px;
+    font: 28px Arial, Helvetica, sans-serif;
     color: #000000;
-    font-family: Arial, Helvetica, sans-serif;
-    font-weight: regular;
     margin: 10px 0;
+  }
+
+  p {
+    margin: 5px 0;
   }
 
   .body p b,
   .body p a {
-    font-size: 12px;
+    font: 12px Arial, Helvetica, sans-serif;;
     color: #000000;
-    font-family: Arial, Helvetica, sans-serif;
   }
 
   .body p {
-    font-size: 13px;
+    font: 13px/19.5px Arial, Helvetica, sans-serif;
     color: #666666;
     margin: 10px 0;
-    font-family: Arial, Helvetica, sans-serif;
-    line-height: 1.5;
   }
 
   ul {
@@ -37,6 +37,24 @@
     text-decoration: none !important;
   }
 
+  /* Outlook Fixes */
+
+  html,
+  body {
+    margin: 0 auto !important;
+    padding: 0 !important;
+    height: 100% !important;
+    width: 100% !important;
+  }
+
+  /* Stop Outlook from adding extra spacing to tables. */
+  table,
+  td {
+    mso-table-lspace: 0pt !important;
+    mso-table-rspace: 0pt !important;
+  }
+
+
   @media only screen and (max-width: 650px) {
     /* mobile-specific CSS styles go here */
     .top {
@@ -47,7 +65,10 @@
       height: auto !important;
     }
     .main {
-      width: 300px !important;
+      width: 330px !important;
+    }
+    .mobileBorder {
+      width: 200px !important;
     }
     .main .right {
       margin-right: 5px;

--- a/packages/common/utils/get-alignment.js
+++ b/packages/common/utils/get-alignment.js
@@ -1,0 +1,3 @@
+const isEven = require('./is-even');
+
+module.exports = index => (isEven(index) ? 'left' : 'right');

--- a/packages/common/utils/is-even.js
+++ b/packages/common/utils/is-even.js
@@ -1,0 +1,1 @@
+module.exports = index => index % 2 === 0;

--- a/packages/common/utils/is-first.js
+++ b/packages/common/utils/is-first.js
@@ -1,0 +1,1 @@
+module.exports = index => index === 0;

--- a/tenants/multi/templates/ien-today-refresh.marko
+++ b/tenants/multi/templates/ien-today-refresh.marko
@@ -1,0 +1,66 @@
+import contentList from "@industrial-media/common/graphql/fragments/content-list";
+
+$ const { website } = out.global;
+$ const { newsletter, date, dateInfo } = data;
+$ const primaryColor = "#ee0228";
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-static-styles />
+  </@head>
+  <@body style="margin: 0px !important; padding: 0 !important; mso-line-height-rule: exactly;">
+    <tenant-banner-element
+      newsletter=newsletter
+      date=date
+      date-info=dateInfo
+    />
+
+<!-- Header -->
+
+    <common-default-header-block
+      name=newsletter.name
+      href=website.get("origin")
+      image-src="/files/base/indm/ien/image/2020/03/today.5e6a9734444ee.png"
+      image-width=420
+      bg-color="#ffffff"
+    >
+      <@wrapper date=date separator-type="date"/>
+    </common-default-header-block>
+
+<!-- Content -->
+
+    <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=0 spacing=0>
+      <tr>
+        <td>
+          <common-grid-block
+            section-id=64040,
+            limit=4,
+            date=date,
+            newsletter=newsletter,
+            primary-color=primaryColor,
+          />
+        </td>
+      </tr>
+    </common-table>
+
+    <common-feed-full-block
+      section-id=64041,
+      date=date,
+      newsletter=newsletter,
+      primary-color=primaryColor,
+      show-teaser=false,
+      two-column=true,
+    />
+
+<!-- Footer/OptOut -->
+
+    <common-default-footer-block />
+
+    <marko-newsletters-mc-open-counter />
+
+  </@body>
+</marko-newsletter-root>


### PR DESCRIPTION
Created new “Refresh” eNL, which is a replica of IEN Today with a new design.  The existing templates should remain unchanged until this new one’s been approved by the group.  

https://southcomm.atlassian.net/browse/BCMS-620

![Screen Shot 2020-07-22 at 4 45 10 PM](https://user-images.githubusercontent.com/12496550/88232217-17a44600-cc3b-11ea-8b9c-8f4f327a72fc.png)

The lower half of the newsletter pulls the "full-feed" block with `twoColumn` set to `true`.  If it's a TextAd, it displays full-width, and all other content displays in columned form.  At first, I organize the non-promotional-content by setting them `left` or `right` based on the `index`, just like the `grid` block does at top of the newsletter.  However, throwing in TextAds at full-width interfered with the index count, so I couldn't order the content `left` or `right` based on even/odd indexing.  That's when I added a `counter` instead.  The counter starts at 0 and resets when it hits a TextAd, so the other content can be arranged as left=odd, right=even.  
![Screen Shot 2020-07-22 at 4 45 22 PM](https://user-images.githubusercontent.com/12496550/88232226-1a06a000-cc3b-11ea-9539-188b491a9c1d.png)
