### PR TITLE
Alignment fix on Text Ad block

### DIFF
--- a/packages/common/components/blocks/content/feed-full.marko
+++ b/packages/common/components/blocks/content/feed-full.marko
@@ -176,7 +176,7 @@ $ const textAdButtonLinkStyle = {
 
                 <else-if(node.type === 'text-ad')>
                   $ counter = 0;
-                  <common-table width="630" style="border-collapse:collapse;" align="center" class="main" padding=10 spacing=0>
+                  <common-table width="630" style="border-collapse:collapse;" align="left" class="main" padding=10 spacing=0>
                     <tr>
                       <td bgcolor="#ecedee">
                         <marko-core-obj-text obj=node field="name">


### PR DESCRIPTION
Cutting off some text in promotions on newsletters, swapping alignment to “left” to fix.

After:

![Screen Shot 2020-08-04 at 11 10 04 AM](https://user-images.githubusercontent.com/12496550/89318318-3dbae480-d644-11ea-9299-23dbe83b9a85.png)

---------


Before:

![Screen Shot 2020-08-04 at 11 11 17 AM](https://user-images.githubusercontent.com/12496550/89318324-401d3e80-d644-11ea-9714-c0e6bc11cc8b.png)
